### PR TITLE
Fix for text staying selected after done editting

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -60,6 +60,9 @@ chrome.runtime.onMessage.addListener(function(site) {
     span.contentEditable = false;
     span.parentElement.href = href;
 
+    // Removes selection if the text is selected after editting
+    sel.removeAllRanges();
+
     // only fire once
     span.removeEventListener('blur', onblur);
     span.removeEventListener('keydown', onkeydown);


### PR DESCRIPTION
When using the extension, I noticed that the if the scholar tab text is selected when done editting, it will stay selected until the page is reloaded. This is just a very simple fix for that.

Before:
![before](https://cloud.githubusercontent.com/assets/3124968/7164193/a84ddbb6-e36c-11e4-990d-c06f80a50918.png)

After:
![after](https://cloud.githubusercontent.com/assets/3124968/7164242/fe49bfee-e36c-11e4-8065-dd2694062803.png)
